### PR TITLE
Added support for subnet with CIDR equal to VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
 locals {
   cidr_netmask = tonumber(split("/", var.base_cidr_block)[1])
+  unique_subnet = length(var.networks) == 1 && tonumber(var.networks[0].netmask - local.cidr_netmask) == 0 ? true : false
   networks_netmask_to_bits = [for i, v in var.networks: { "name" = v.name, "new_bits" = tonumber(v.netmask - local.cidr_netmask) } ]
   name_prefixes = toset([ for name, _ in local.addrs_by_name: split(var.separator, name)[0] ])
 
-  addrs_by_idx  = cidrsubnets(var.base_cidr_block, local.networks_netmask_to_bits[*].new_bits...)
+  addrs_by_idx  = local.unique_subnet ? [var.base_cidr_block] : cidrsubnets(var.base_cidr_block, local.networks_netmask_to_bits[*].new_bits...)
   addrs_by_name = { for i, n in local.networks_netmask_to_bits : n.name => local.addrs_by_idx[i] if n.name != null }
   network_objs = [for i, n in local.networks_netmask_to_bits : {
     name       = n.name


### PR DESCRIPTION
When I pass subnet with the same CIDR as the VPC an error is thrown.
This modification allows the subnet to have the same CIDR as the VPC. For this module, it doesn't seem to be useful, but as it is used as a base for `aws-ia/terraform-aws-vpc`, if the user wants to do this configuration he will receive the error.